### PR TITLE
Update kaleidoscope.gemspec

### DIFF
--- a/kaleidoscope.gemspec
+++ b/kaleidoscope.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('generator_spec')
   gem.add_development_dependency('railties')
-  gem.add_development_dependency('rails')
   gem.add_development_dependency('pry')
   gem.add_development_dependency('pry-nav')
 end


### PR DESCRIPTION
`kaleidoscope at /Users/dpsk/.rvm/gems/ruby-2.1.1@colorsearch/bundler/gems/kaleidoscope-39198d02ef3c did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on rails (>= 0, development), (>= 4.0.0) use:
    add_runtime_dependency 'rails', '>= 0', '>= 4.0.0'`
